### PR TITLE
Fixed bug - now None can be used as a default value for choixe variables

### DIFF
--- a/pipelime/choixe/visitors/processor.py
+++ b/pipelime/choixe/visitors/processor.py
@@ -112,10 +112,10 @@ class Processor(ast.NodeVisitor):
 
     def visit_var(self, node: ast.VarNode) -> List[Any]:
         id_branches = node.identifier.accept(self)
-        default_brances = node.default.accept(self) if node.default else [None]
+        default_branches = node.default.accept(self) if node.default else [None]
         env_branches = node.env.accept(self) if node.env else [None]
 
-        branches = self._branches(id_branches, default_brances, env_branches)
+        branches = self._branches(id_branches, default_branches, env_branches)
         data = []
 
         for id_, default, env in branches:
@@ -129,7 +129,7 @@ class Processor(ast.NodeVisitor):
                     data.append(value)
                     continue
 
-            if default is not None:
+            if node.default:
                 data.append(default)
                 continue
 

--- a/tests/pipelime/choixe/visitors/test_processor.py
+++ b/tests/pipelime/choixe/visitors/test_processor.py
@@ -62,6 +62,11 @@ class TestProcessor:
         expected = ["red"]
         self._expectation_test(data, expected)
 
+    def test_var_none_default(self):
+        data = "$var(color.sat, default=None)"
+        expected = [None]
+        self._expectation_test(data, expected)
+
     def test_var_missing(self):
         data = "$var(color.sat, default='low')"
         expected = ["low"]


### PR DESCRIPTION
Fixed:
- Typo in `Processor.visit_var` "branches" misspelled as "brances".
- Choixe variables can have a None default value.