### PR TITLE
Fixed, for loops can be used with one element sequences

### DIFF
--- a/pipelime/choixe/visitors/processor.py
+++ b/pipelime/choixe/visitors/processor.py
@@ -210,16 +210,17 @@ class Processor(ast.NodeVisitor):
 
         self._current_loop = prev_loop
 
-        branches = self._branches(*branches)
+        branches = list(product(*branches))
         for i, branch in enumerate(branches):
-            if isinstance(node.body, ast.LiteralNode) or isinstance(
-                node.body, ast.StrBundleNode
-            ):
+            res = None
+            if len(branch) == 0:
+                branches[i] = None
+            elif isinstance(branch[0], (str, int, float, bool)):
                 res = "".join([str(item) for item in branch])
-            elif isinstance(node.body, ast.ListNode):
+            elif isinstance(branch[0], list):
                 res = []
                 [res.extend(item) for item in branch]
-            else:
+            elif isinstance(branch[0], dict):
                 res = {}
                 [res.update(item) for item in branch]
             branches[i] = res

--- a/tests/pipelime/choixe/visitors/test_processor.py
+++ b/tests/pipelime/choixe/visitors/test_processor.py
@@ -343,6 +343,32 @@ class TestProcessor:
         ]
         self._expectation_test(data, expected)
 
+    def test_for_direct_nesting(self):
+        data = {
+            "$for(collection3, x)": {
+                "$for(collection4, y)": ["item_$index(x)_$index(y)=$item(y)"]
+            }
+        }
+        expected = [
+            ["item_0_0=100", "item_0_1=101", "item_1_0=100", "item_1_1=101"],
+        ]
+        self._expectation_test(data, expected)
+
+    def test_for_one_element_dict(self):
+        data = {"$for(1)": {"$index": "$index"}}
+        expected = [{0: 0}]
+        self._expectation_test(data, expected)
+
+    def test_for_one_element_list(self):
+        data = {"$for(1)": ["$index"]}
+        expected = [[0]]
+        self._expectation_test(data, expected)
+
+    def test_for_one_element_str(self):
+        data = {"$for(1)": "$index"}
+        expected = ["0"]
+        self._expectation_test(data, expected)
+
     def test_for_nested_compact(self):
         data = {
             "$for(collection3)": {


### PR DESCRIPTION
Bugfixes:
- Choixe for loop did not work when directly nesting two loops with a list. Now, the type of result (str, list, dict) is computed from the type of the partially processed contents, instead from the unprocessed ast nodes.
- Choixe for loop not working with 1-element iterables. For loops misused an utility private method that removed a dimension from the branch matrix when the number of branches was exactly one.