### PR TITLE
Cvops 84 choixe empty list bug with switch case

### DIFF
--- a/tests/pipelime/choixe/visitors/test_processor.py
+++ b/tests/pipelime/choixe/visitors/test_processor.py
@@ -455,7 +455,6 @@ class TestProcessor:
             ]
         }
         expected = [20]
-        print(process(parse(data)))
         self._expectation_test(data, expected)
 
     def test_switch_default(self):


### PR DESCRIPTION
Bugfixes:
- If the switch-case variable is not found in the context, an appropriate error will be raised instead of using `None`.
- If the switch-case has no default and no case matches, an appropriate error will be raised instead of returning 0 branches causing the sweep cartesian product to collapse to empty set.