### PR TITLE
fix: :bug: Add unsafe processing methods to XConfig

### DIFF
--- a/docs/choixe/xconfig.md
+++ b/docs/choixe/xconfig.md
@@ -107,6 +107,33 @@ output = cfg.process()
 outputs = cfg.process_all()
 ```
 
+### Unsafe processing variant
+
+The `process` and `process_all` methods always return a new `XConfig` object, but sometimes you might want to use an `XConfig` to create a completely different object that cannot be represented as a `XConfig`, like a `numpy.ndarray` or a `pydantic.BaseModel` or anything else. In this case, you can use the `unsafe_process` and `unsafe_process_all` methods, which will return the result of the processing, without creating a new `XConfig` object. 
+
+These methods don't perform any validation on the result, all typing and content checks are left to the user, and you should use them only if you want to allow different types of objects to be returned by the choixe processing.
+
+Example:
+
+```python
+import numpy as np
+
+cfg = {
+    "$call": "numpy.array",
+    "$args": {
+        "object": [1, 2, 3],
+    }
+}
+xcfg = XConfig(cfg)
+
+# xcfg.process() <--- This will raise an error
+
+result = xcfg.unsafe_process() # <--- This will return a numpy.ndarray
+
+assert isinstance(result, np.ndarray)
+assert np.array_equal(result, np.array([1, 2, 3]))
+```
+
 ## Inspection
 What if you just loaded an XConfig and are about to process it, only, you don't know what to pass as **context**, what environment variables are required, or what files are going to be imported. You can use the `inspect` method, to get some info on the `XConfig` that you are about to process.
 

--- a/pipelime/choixe/xconfig.py
+++ b/pipelime/choixe/xconfig.py
@@ -226,15 +226,20 @@ class XConfig(Box):
     def _process(
         self, context: Optional[Dict[str, Any]] = None, allow_branching: bool = True
     ) -> List[XConfig]:
-        data = process(
+        data = self._unsafe_process(context=context, allow_branching=allow_branching)
+        return [
+            XConfig(data=x, cwd=self.get_cwd(), schema=self.get_schema()) for x in data
+        ]
+
+    def _unsafe_process(
+        self, context: Optional[Dict[str, Any]] = None, allow_branching: bool = True
+    ) -> List[Any]:
+        return process(
             self.parse(),
             context=context,
             cwd=self.get_cwd(),
             allow_branching=allow_branching,
         )
-        return [
-            XConfig(data=x, cwd=self.get_cwd(), schema=self.get_schema()) for x in data
-        ]
 
     def process(self, context: Optional[Dict[str, Any]] = None) -> XConfig:
         """Process this XConfig without branching.
@@ -248,6 +253,22 @@ class XConfig(Box):
         """
         return self._process(context=context, allow_branching=False)[0]
 
+    def unsafe_process(self, context: Optional[Dict[str, Any]] = None) -> Any:
+        """Process this XConfig without branching and return the result, without
+        wrapping it in an XConfig to allow for more flexibility in the result.
+
+        No guarantees can be made about the result type, so it is up to the user to
+        handle it properly.
+
+        Args:
+            context (Optional[Dict[str, Any]], optional): Optional data structure
+                containing all variables values. Defaults to None.
+
+        Returns:
+            Any: The processed result.
+        """
+        return self._unsafe_process(context=context, allow_branching=False)[0]
+
     def process_all(self, context: Optional[Dict[str, Any]] = None) -> List[XConfig]:
         """Process this XConfig with branching.
 
@@ -259,6 +280,22 @@ class XConfig(Box):
             List[XConfig]: A list of all processing outcomes.
         """
         return self._process(context=context, allow_branching=True)
+
+    def unsafe_process_all(self, context: Optional[Dict[str, Any]] = None) -> List[Any]:
+        """Process this XConfig with branching and return the results, without
+        wrapping them in XConfigs to allow for more flexibility in the result.
+
+        No guarantees can be made about the result types, so it is up to the user to
+        handle them properly.
+
+        Args:
+            context (Optional[Dict[str, Any]], optional): Optional data structure
+                containing all variables values. Defaults to None.
+
+        Returns:
+            List[Any]: A list of all processing outcomes.
+        """
+        return self._unsafe_process(context=context, allow_branching=True)
 
     def inspect(self) -> Inspection:
         return inspect(self.parse(), cwd=self.get_cwd())


### PR DESCRIPTION
Unsafe processing returns anything, no additional XConfig wrap is done afterwards do allow for maximum flexibility