### PR TITLE
Feature/more useful commands

### DIFF
--- a/pipelime/commands/__init__.py
+++ b/pipelime/commands/__init__.py
@@ -13,7 +13,7 @@ from pipelime.commands.general import (
     SliceCommand,
     SetMetadataCommand,
     FilterDuplicatesCommand,
-    CopySharedItems,
+    CopySharedItemsCommand,
 )
 from pipelime.commands.shell import ShellCommand
 from pipelime.commands.split_ops import (

--- a/pipelime/commands/__init__.py
+++ b/pipelime/commands/__init__.py
@@ -13,6 +13,7 @@ from pipelime.commands.general import (
     SliceCommand,
     SetMetadataCommand,
     FilterDuplicatesCommand,
+    CopySharedItems,
 )
 from pipelime.commands.shell import ShellCommand
 from pipelime.commands.split_ops import (

--- a/pipelime/commands/general.py
+++ b/pipelime/commands/general.py
@@ -953,23 +953,36 @@ class FilterDuplicatesCommand(PipelimeCommand, title="filter-duplicates"):
             key += "_"
 
 
-class CopySharedItems(PipelimeCommand, title="copy-shared-items"):
+class CopySharedItemsCommand(PipelimeCommand, title="copy-shared-items"):
     """Copy shared items from a source dataset to a destination dataset. Datasets may
     not have the same length."""
 
     source: pl_interfaces.InputDatasetInterface = (
         pl_interfaces.InputDatasetInterface.pyd_field(
-            alias="src", piper_port=PiperPortType.INPUT
+            alias="src",
+            piper_port=PiperPortType.INPUT,
+            description=(
+                "Where the shared items are copied from. Must have at least one "
+                "sample and one shared item."
+            ),
         )
     )
     dest: pl_interfaces.InputDatasetInterface = (
         pl_interfaces.InputDatasetInterface.pyd_field(
-            alias="dst", piper_port=PiperPortType.INPUT
+            alias="dst",
+            piper_port=PiperPortType.INPUT,
+            description=(
+                "Where the shared items are copied to. Must have at least one sample "
+                "and any number of shared items. Source and destination datasets may "
+                "not have the same length, as only the shared items are copied."
+            ),
         )
     )
     output: pl_interfaces.OutputDatasetInterface = (
         pl_interfaces.OutputDatasetInterface.pyd_field(
-            alias="o", piper_port=PiperPortType.OUTPUT
+            alias="o",
+            piper_port=PiperPortType.OUTPUT,
+            description=("Where the resulting dataset is written to."),
         )
     )
 

--- a/pipelime/stages/__init__.py
+++ b/pipelime/stages/__init__.py
@@ -5,7 +5,7 @@ from pipelime.stages.base import (
     StageLambda,
     StageInput,
 )
-from pipelime.stages.augmentations import StageAlbumentations, StageResizeImages
+from pipelime.stages.augmentations import StageAlbumentations, StageResize
 from pipelime.stages.item_replacement import (
     StageReplaceItem,
     StageSetMetadata,

--- a/pipelime/stages/__init__.py
+++ b/pipelime/stages/__init__.py
@@ -5,7 +5,7 @@ from pipelime.stages.base import (
     StageLambda,
     StageInput,
 )
-from pipelime.stages.augmentations import StageAlbumentations
+from pipelime.stages.augmentations import StageAlbumentations, StageResizeImages
 from pipelime.stages.item_replacement import (
     StageReplaceItem,
     StageSetMetadata,

--- a/pipelime/stages/__init__.py
+++ b/pipelime/stages/__init__.py
@@ -5,7 +5,11 @@ from pipelime.stages.base import (
     StageLambda,
     StageInput,
 )
-from pipelime.stages.augmentations import StageAlbumentations, StageResize
+from pipelime.stages.augmentations import (
+    StageAlbumentations,
+    StageResize,
+    StageCropAndPad,
+)
 from pipelime.stages.item_replacement import (
     StageReplaceItem,
     StageSetMetadata,

--- a/pipelime/stages/__init__.py
+++ b/pipelime/stages/__init__.py
@@ -14,6 +14,7 @@ from pipelime.stages.item_replacement import (
     StageReplaceItem,
     StageSetMetadata,
     StageSampleHash,
+    StageShareItems,
 )
 from pipelime.stages.item_sources import StageForgetSource, StageUploadToRemote
 from pipelime.stages.key_transformations import (

--- a/pipelime/stages/augmentations.py
+++ b/pipelime/stages/augmentations.py
@@ -110,7 +110,7 @@ class StageAlbumentations(SampleStage, title="albumentations"):
         return x
 
 
-class StageResize(SampleStage, title="resize"):
+class StageResize(SampleStage, title="resize-images"):
     """Helper stage to resize images and masks without having to define a
     full albumentations transformation.
     """
@@ -177,7 +177,7 @@ class StageResize(SampleStage, title="resize"):
         return self._wrapped(x)
 
 
-class StageCropAndPad(SampleStage, title="crop-and-pad"):
+class StageCropAndPad(SampleStage, title="crop-and-pad-images"):
     """Helper stage to crop and pad images in a desired size without having to define
     a full albumentations transformation."""
 

--- a/pipelime/stages/augmentations.py
+++ b/pipelime/stages/augmentations.py
@@ -8,8 +8,7 @@ from pydantic.color import Color
 
 from pipelime.stages import SampleStage
 
-if t.TYPE_CHECKING:
-    from pipelime.sequences import Sample
+from pipelime.sequences import Sample
 
 
 class Transformation(pyd.BaseModel, extra="forbid", copy_on_model_validation="none"):
@@ -110,7 +109,7 @@ class StageAlbumentations(SampleStage, title="albumentations"):
         return x
 
 
-class StageResizeImages(SampleStage, title="resize-images"):
+class StageResize(SampleStage, title="resize"):
     """Helper stage to resize images and masks without having to define a
     full albumentations transformation.
     """
@@ -177,7 +176,7 @@ class StageResizeImages(SampleStage, title="resize-images"):
         return self._wrapped(x)
 
 
-class CropAndPad(SampleStage):
+class CropAndPad(SampleStage, title="crop-and-pad"):
     """Helper stage to crop and pad images in a desired size without having to define
     a full albumentations transformation."""
 

--- a/pipelime/stages/augmentations.py
+++ b/pipelime/stages/augmentations.py
@@ -8,7 +8,8 @@ from pydantic.color import Color
 
 from pipelime.stages import SampleStage
 
-from pipelime.sequences import Sample
+if t.TYPE_CHECKING:
+    from pipelime.sequences import Sample
 
 
 class Transformation(pyd.BaseModel, extra="forbid", copy_on_model_validation="none"):
@@ -100,7 +101,7 @@ class StageAlbumentations(SampleStage, title="albumentations"):
 
         self.transform.value.add_targets(target_types)
 
-    def __call__(self, x: Sample) -> Sample:
+    def __call__(self, x: "Sample") -> "Sample":
         to_transform = {k: x[v]() for k, v in self._target_to_keys.items() if v in x}
         transformed = self.transform.value(**to_transform)  # type: ignore
         for k, v in transformed.items():
@@ -172,7 +173,7 @@ class StageResize(SampleStage, title="resize"):
             output_key_format=self.output_key_format,
         )
 
-    def __call__(self, x: Sample) -> Sample:
+    def __call__(self, x: "Sample") -> "Sample":
         return self._wrapped(x)
 
 
@@ -220,7 +221,7 @@ class StageCropAndPad(SampleStage, title="crop-and-pad"):
         "*", description="How to format the output keys."
     )
 
-    def __call__(self, x: Sample) -> Sample:
+    def __call__(self, x: "Sample") -> "Sample":
         import cv2
 
         img_keys = [self.images] if isinstance(self.images, str) else self.images

--- a/pipelime/stages/augmentations.py
+++ b/pipelime/stages/augmentations.py
@@ -176,7 +176,7 @@ class StageResize(SampleStage, title="resize"):
         return self._wrapped(x)
 
 
-class CropAndPad(SampleStage, title="crop-and-pad"):
+class StageCropAndPad(SampleStage, title="crop-and-pad"):
     """Helper stage to crop and pad images in a desired size without having to define
     a full albumentations transformation."""
 
@@ -206,7 +206,7 @@ class CropAndPad(SampleStage, title="crop-and-pad"):
             "If 0 no cropping or padding is done."
         ),
     )
-    pad_border: t.Literal["constant", "reflect", "replicate", "circular"] = pyd.Field(
+    border: t.Literal["constant", "reflect", "replicate", "circular"] = pyd.Field(
         "constant", description="Padding mode."
     )
     pad_colors: t.Union[Color, t.Sequence[Color]] = pyd.Field(
@@ -229,8 +229,6 @@ class CropAndPad(SampleStage, title="crop-and-pad"):
             [self.pad_colors] if isinstance(self.pad_colors, Color) else self.pad_colors
         )
 
-        if len(out_keys) < len(img_keys):
-            out_keys = list(out_keys) + list(img_keys[len(out_keys) :])
         if len(colors) < len(img_keys):
             colors = list(colors) + [Color("black")] * (len(img_keys) - len(colors))
 
@@ -277,7 +275,7 @@ class CropAndPad(SampleStage, title="crop-and-pad"):
                     bottom=pad_bottom,
                     left=pad_left,
                     right=pad_right,
-                    borderType=cv_border[self.pad_border],
+                    borderType=cv_border[self.border],
                     value=pad_col.as_rgb_tuple(alpha=False),
                 )
 

--- a/tests/pipelime/commands/test_copy_shared_items.py
+++ b/tests/pipelime/commands/test_copy_shared_items.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+from .test_general_base import TestGeneralCommandsBase
+
+
+class TestSetCopySharedItemsCommand(TestGeneralCommandsBase):
+    def test_set_meta(self, minimnist_dataset, tmp_path):
+        from pipelime.commands import CopySharedItemsCommand
+        from pipelime.sequences import SamplesSequence
+
+        def _check_output(path):
+            outseq = SamplesSequence.from_underfolder(path)
+            for x in outseq:
+                if x.deep_get("metadata.double") == 6:
+                    assert x.deep_get("metadata.the_answer") == "fourtytwo"
+
+        params = {
+            "input": minimnist_dataset["path"].as_posix(),
+            "output": (tmp_path / "output_key").as_posix(),
+            "grabber": f"{nproc},{prefetch}",
+            "filter_query": "`metadata.double` == 6",
+            "key_path": "metadata.the_answer",
+            "value": "fourtytwo",
+        }
+        cmd = SetMetadataCommand.parse_obj(params)
+        cmd()
+        _check_output(params["output"])
+
+        params["output"] = (tmp_path / "output_fn").as_posix()
+        params["filter_fn"] = f"{Path(__file__).with_name('helper.py')}:set_meta_fn"
+        with pytest.raises(ValueError):
+            cmd = SetMetadataCommand.parse_obj(params)
+
+        del params["filter_query"]
+        if nproc == 0:
+            cmd = SetMetadataCommand.parse_obj(params)
+            cmd()
+            _check_output(params["output"])
+            with pytest.raises(ValueError):
+                cmd = SetMetadataCommand.parse_obj(params)  # output exists
+        else:
+            del params["filter_fn"]
+            with pytest.raises(ValueError):
+                cmd = SetMetadataCommand.parse_obj(params)

--- a/tests/pipelime/stages/test_augmentations.py
+++ b/tests/pipelime/stages/test_augmentations.py
@@ -177,4 +177,51 @@ class TestResize:
 
 
 class TestCropAndPad:
-    pass
+    @pytest.mark.parametrize(
+        ["x", "y", "w", "h"],
+        [(0, 0, 10, 10), (1, 15, 50, 10), (0, 0, 1, 1), (10, -100, 1000, 200)],
+    )
+    @pytest.mark.parametrize("border", ["constant", "reflect", "replicate", "circular"])
+    def test_stage(self, x, y, w, h, border) -> None:
+        from pipelime.stages import StageCropAndPad
+        import pipelime.items as pli
+        import numpy as np
+
+        stage = StageCropAndPad(
+            x=x,
+            y=y,
+            width=w,
+            height=h,
+            images=["image", "mask1", "mask2"],
+            border=border,
+            output_key_format="*_crop",
+        )  # type: ignore
+
+        sample = Sample(
+            {
+                "image": pli.PngImageItem(
+                    np.random.randint(0, 255, (200, 100, 3), dtype=np.uint8)
+                ),
+                "mask1": pli.PngImageItem(
+                    np.random.randint(0, 255, (200, 100), dtype=np.uint8)
+                ),
+                "mask2": pli.PngImageItem(
+                    np.random.randint(0, 255, (200, 100, 10), dtype=np.uint8)
+                ),
+            }
+        )
+
+        sample = stage(sample)
+
+        in_keys = ["image", "mask1", "mask2"]
+        out_keys = [f"{k}_crop" for k in in_keys]
+        for in_key, out_key in zip(in_keys, out_keys):
+            assert in_key in sample
+            assert out_key in sample
+            orig_image = sample[in_key]()
+            cropped_image = sample[out_key]()
+            assert isinstance(orig_image, np.ndarray)
+            assert isinstance(cropped_image, np.ndarray)
+            if len(cropped_image.shape) == 3:
+                assert cropped_image.shape[2] == orig_image.shape[2]
+            assert cropped_image.shape[:2] == (h, w)

--- a/tests/pipelime/stages/test_augmentations.py
+++ b/tests/pipelime/stages/test_augmentations.py
@@ -121,3 +121,60 @@ class TestAugmentationStages:
                 transform=42,
                 keys_to_targets={"image": "image"},
             )
+
+
+class TestResize:
+    @pytest.mark.parametrize(
+        "size", [(10, 10), (50, 10), (1, 1), ("max", 20), ("min", 20)]
+    )
+    @pytest.mark.parametrize("interpolation", ["nearest", "bilinear", "bicubic"])
+    def test_stage(self, size, interpolation) -> None:
+        from pipelime.stages import StageResize
+        import pipelime.items as pli
+        import numpy as np
+
+        stage = StageResize(
+            size=size,
+            interpolation=interpolation,
+            images="image",
+            masks=["mask1", "mask2"],
+            output_key_format="*_resized",
+        )
+
+        sample = Sample(
+            {
+                "image": pli.PngImageItem(
+                    np.random.randint(0, 255, (200, 100, 3), dtype=np.uint8)
+                ),
+                "mask1": pli.PngImageItem(
+                    np.random.randint(0, 255, (200, 100), dtype=np.uint8)
+                ),
+                "mask2": pli.PngImageItem(
+                    np.random.randint(0, 255, (200, 100, 10), dtype=np.uint8)
+                ),
+            }
+        )
+
+        sample = stage(sample)
+
+        in_keys = ["image", "mask1", "mask2"]
+        out_keys = [f"{k}_resized" for k in in_keys]
+        for in_key, out_key in zip(in_keys, out_keys):
+            assert in_key in sample
+            assert out_key in sample
+            orig_image = sample[in_key]()
+            resized_image = sample[out_key]()
+            assert isinstance(orig_image, np.ndarray)
+            assert isinstance(resized_image, np.ndarray)
+            if isinstance(size[0], int):
+                assert resized_image.shape[:2] == size
+            elif size[0] == "max":
+                assert max(resized_image.shape[:2]) == size[1]
+            else:
+                assert min(resized_image.shape[:2]) == size[1]
+            if len(resized_image.shape) == 3:
+                assert resized_image.shape[2] == orig_image.shape[2]
+
+
+class TestCropAndPad:
+    pass

--- a/tests/pipelime/stages/test_item_replacement.py
+++ b/tests/pipelime/stages/test_item_replacement.py
@@ -1,0 +1,61 @@
+import pytest
+import pipelime.items as pli
+import pipelime.sequences as pls
+import pipelime.stages as plst
+
+
+@pytest.fixture
+def simple_sample():
+    return pls.Sample(
+        {
+            "a": pli.YamlMetadataItem({"a": 10}),
+            "b": pli.YamlMetadataItem({"b": 20}),
+            "c": pli.YamlMetadataItem({"c": 30}, shared=True),
+            "d": pli.YamlMetadataItem({"d": 40}, shared=True),
+        },
+    )
+
+
+class TestStageShareItems:
+    @pytest.mark.parametrize(
+        "share, unshare",
+        # list of disjoint sets.
+        [
+            ([], []),
+            (["a"], []),
+            ([], ["a"]),
+            (["a"], ["b"]),
+            (["a", "b"], []),
+            ([], ["a", "b"]),
+            (["a", "b"], ["d"]),
+            (["a", "c"], ["b", "d"]),
+            ([], ["a", "b", "c", "d"]),
+            (["a", "b", "c", "d"], []),
+        ],
+    )
+    def test_stage(self, simple_sample, share, unshare):
+        expected = {k: v.is_shared for k, v in simple_sample.items()}
+        for k in share:
+            expected[k] = True
+        for k in unshare:
+            expected[k] = False
+
+        stage = plst.StageShareItems(share=share, unshare=unshare)
+        actual = stage(simple_sample)
+
+        for k, v in actual.items():
+            assert v.is_shared == expected[k]
+
+    @pytest.mark.parametrize(
+        "share, unshare",
+        # list of non-disjoint sets.
+        [
+            (["a", "b"], ["b", "c"]),
+            (["a", "b"], ["b", "a"]),
+            (["a", "b"], ["a", "b"]),
+            (["a", "b"], ["a", "b", "c"]),
+        ],
+    )
+    def test_stage_fails_with_non_disjoint_sets(self, share, unshare):
+        with pytest.raises(ValueError):
+            plst.StageShareItems(share=share, unshare=unshare)


### PR DESCRIPTION
Added:
- `resize` stage that lets you quickly resize a set of images/masks with custom interpolation
- `crop_and_pad` stage that lets you quickly crop or pad a set of images/masks with custom border modes, padding colors etc..
- `copy-shared-items` command that copies a set of shared items from a dataset to another. 

These changes don't actually add anything new, they are just helpers for existing features that normally require you to write many lines of code to use. 