### PR TITLE
Several fixes for TUI and for multiprocessing

### DIFF
--- a/pipelime/choixe/ast/nodes.py
+++ b/pipelime/choixe/ast/nodes.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import field
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
-# from dataclasses import dataclass
 from pydantic.dataclasses import dataclass
 
 
@@ -336,7 +336,7 @@ class RandNode(Node):
 
     args: Sequence[HashNode] = tuple()
     n: Optional[Node] = None
-    pdf: Optional[Node] = None
+    pdf: Optional[Node] = field(default=None, compare=False)
 
     def __init__(self, *args: HashNode, **data) -> None:
         super().__init__()

--- a/pipelime/cli/tui/tui.css
+++ b/pipelime/cli/tui/tui.css
@@ -19,7 +19,7 @@
 }
 
 .description {
-    height: 0;
+    height: auto;
     opacity: 0.5;
 }
 

--- a/pipelime/cli/tui/tui.py
+++ b/pipelime/cli/tui/tui.py
@@ -89,7 +89,7 @@ class SaveScreen(ModalScreen):
             error_label.display = True
             error = str(e)
             # escape the square brackets to avoid rich syntax
-            error = error.replace("[", "\[")  # noqa: W605
+            error = error.replace("[", r"\[")  # noqa: W605
             error_label.update(error)
 
     def action_cancel(self) -> None:
@@ -319,7 +319,7 @@ class TuiApp(App[Mapping]):
                 replace_whitespace=False,
                 tabsize=4,
             )
-            sub = sub.replace("[", "\[")  # noqa: W605
+            sub = sub.replace("[", r"\[")  # noqa: W605
             preprocessed += sub + "\n"
 
         preprocessed = preprocessed[:-1]

--- a/pipelime/cli/tui/tui.py
+++ b/pipelime/cli/tui/tui.py
@@ -30,7 +30,7 @@ class Constants:
     SUB_FIELD_MARGIN = (0, 0, 0, 4)
     TUI_KEY_CONFIRM = Keys.ControlN
     TUI_KEY_SAVE = Keys.ControlS
-    TUI_KEY_ABORT = Keys.ControlB
+    TUI_KEY_ABORT = Keys.ControlT
     TUI_KEY_TOGGLE_DESCRIPTIONS = Keys.ControlJ
     SAVE_KEY_CONFIRM = Keys.ControlS
     SAVE_KEY_CANCEL = Keys.Escape

--- a/pipelime/commands/interfaces.py
+++ b/pipelime/commands/interfaces.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 from pathlib import Path
 from urllib.parse import ParseResult
-import uuid
 
 import pydantic as pyd
 
@@ -92,7 +92,9 @@ class GrabberInterface(PydanticFieldWithDefaultMixin, pyd.BaseModel, extra="forb
     """
 
     _default_type_description: t.ClassVar[t.Optional[str]] = "Grabber options."
-    _compact_form: t.ClassVar[t.Optional[str]] = "<num_workers>[,<prefetch>]"
+    _compact_form: t.ClassVar[t.Optional[str]] = (
+        "<num_workers>[,<prefetch>[,<allow_nested_mp>]]"
+    )
 
     num_workers: int = pyd.Field(
         0,
@@ -103,6 +105,9 @@ class GrabberInterface(PydanticFieldWithDefaultMixin, pyd.BaseModel, extra="forb
     )
     prefetch: pyd.PositiveInt = pyd.Field(
         2, description="The number of samples loaded in advanced by each worker."
+    )
+    allow_nested_mp: bool = pyd.Field(
+        False, description="Whether to allow nested multiprocessing."
     )
 
     @classmethod
@@ -119,15 +124,20 @@ class GrabberInterface(PydanticFieldWithDefaultMixin, pyd.BaseModel, extra="forb
             if isinstance(value, int):
                 data["num_workers"] = value
             else:
-                wrks, _, pf = str(value).partition(",")
-                if wrks:
-                    data["num_workers"] = int(wrks)
-                if pf:
-                    data["prefetch"] = int(pf)
+                raw_data = str(value).split(",")
+                try:
+                    data["num_workers"] = int(raw_data[0])
+                    if len(raw_data) > 1:
+                        data["prefetch"] = int(raw_data[1])
+                    if len(raw_data) > 2:
+                        data["allow_nested_mp"] = raw_data[2].lower() == "true"
+                except ValueError:
+                    raise ValueError("Invalid grabber definition.")
             value = data
 
         if isinstance(value, t.Mapping):
             return GrabberInterface(**value)
+
         raise ValueError("Invalid grabber definition.")
 
     def grab_all(
@@ -176,9 +186,11 @@ class GrabberInterface(PydanticFieldWithDefaultMixin, pyd.BaseModel, extra="forb
             sample_fn=sample_fn,
             size=size,
             grab_context_manager=grab_context_manager,
-            worker_init_fn=None
-            if grab_context_manager is None
-            else deepcopy(grab_context_manager).__enter__,
+            worker_init_fn=(
+                None
+                if grab_context_manager is None
+                else deepcopy(grab_context_manager).__enter__
+            ),
         )
 
     def grab_all_wrk_init(
@@ -221,7 +233,10 @@ class GrabberInterface(PydanticFieldWithDefaultMixin, pyd.BaseModel, extra="forb
         from pipelime.sequences import Grabber, grab_all
 
         grabber = Grabber(
-            num_workers=self.num_workers, prefetch=self.prefetch, keep_order=keep_order
+            num_workers=self.num_workers,
+            prefetch=self.prefetch,
+            keep_order=keep_order,
+            allow_nested_mp=self.allow_nested_mp,
         )
         track_fn = (
             None
@@ -498,9 +513,9 @@ class OutputDatasetInterface(
     """
 
     _default_type_description: t.ClassVar[t.Optional[str]] = "The output dataset."
-    _compact_form: t.ClassVar[
-        t.Optional[str]
-    ] = "<folder>[,<exists_ok>[,<force_new_files>]]"
+    _compact_form: t.ClassVar[t.Optional[str]] = (
+        "<folder>[,<exists_ok>[,<force_new_files>]]"
+    )
     _default_port_type: t.ClassVar[PiperPortType] = PiperPortType.OUTPUT
 
     folder: t.Optional[Path] = pyd.Field(
@@ -699,9 +714,9 @@ class RemoteInterface(
 ):
     """Remote data lake options."""
 
-    _default_type_description: t.ClassVar[
-        t.Optional[str]
-    ] = "Remote data lakes addresses."
+    _default_type_description: t.ClassVar[t.Optional[str]] = (
+        "Remote data lakes addresses."
+    )
     _compact_form: t.ClassVar[t.Optional[str]] = "<url>"
     _default_port_type: t.ClassVar[PiperPortType] = PiperPortType.INPUT
 

--- a/pipelime/commands/interfaces.py
+++ b/pipelime/commands/interfaces.py
@@ -126,10 +126,11 @@ class GrabberInterface(PydanticFieldWithDefaultMixin, pyd.BaseModel, extra="forb
             else:
                 raw_data = str(value).split(",")
                 try:
-                    data["num_workers"] = int(raw_data[0])
-                    if len(raw_data) > 1:
+                    if raw_data[0]:
+                        data["num_workers"] = int(raw_data[0])
+                    if len(raw_data) > 1 and raw_data[1]:
                         data["prefetch"] = int(raw_data[1])
-                    if len(raw_data) > 2:
+                    if len(raw_data) > 2 and raw_data[2]:
                         data["allow_nested_mp"] = raw_data[2].lower() == "true"
                 except ValueError:
                     raise ValueError("Invalid grabber definition.")

--- a/pipelime/commands/split_ops.py
+++ b/pipelime/commands/split_ops.py
@@ -13,12 +13,12 @@ class SplitBase(
     extra="forbid",
     copy_on_model_validation="none",
 ):
-    output: t.Optional[
-        pl_interfaces.OutputDatasetInterface
-    ] = pl_interfaces.OutputDatasetInterface.pyd_field(
-        alias="o",
-        is_required=False,
-        description="Output split. Leave to None to not save to disk.",
+    output: t.Optional[pl_interfaces.OutputDatasetInterface] = (
+        pl_interfaces.OutputDatasetInterface.pyd_field(
+            alias="o",
+            is_required=False,
+            description="Output split. Leave to None to not save to disk.",
+        )
     )
 
     def __repr__(self) -> str:
@@ -29,9 +29,9 @@ class SplitBase(
 
 
 class PercSplit(SplitBase):
-    _default_type_description: t.ClassVar[
-        t.Optional[str]
-    ] = "Percentage splits definition."
+    _default_type_description: t.ClassVar[t.Optional[str]] = (
+        "Percentage splits definition."
+    )
     _compact_form: t.ClassVar[t.Optional[str]] = "<fraction>[,<folder>]"
 
     fraction: t.Optional[float] = pyd.Field(
@@ -79,9 +79,9 @@ class PercSplit(SplitBase):
 
 
 class AbsoluteSplit(SplitBase):
-    _default_type_description: t.ClassVar[
-        t.Optional[str]
-    ] = "Absolute splits definition."
+    _default_type_description: t.ClassVar[t.Optional[str]] = (
+        "Absolute splits definition."
+    )
     _compact_form: t.ClassVar[t.Optional[str]] = "<length>[,<folder>]"
 
     length: t.Optional[pyd.PositiveInt] = pyd.Field(
@@ -245,28 +245,28 @@ class SplitByQueryCommand(PipelimeCommand, title="split-query"):
         description=("A query to match (cfr. https://github.com/cyberlis/dictquery)."),
     )
 
-    output_selected: t.Optional[
-        pl_interfaces.OutputDatasetInterface
-    ] = pl_interfaces.OutputDatasetInterface.pyd_field(
-        alias="os",
-        is_required=False,
-        description=(
-            "Output dataset of sample selected by the query. "
-            "Leave to None to not save to disk."
-        ),
-        piper_port=PiperPortType.OUTPUT,
+    output_selected: t.Optional[pl_interfaces.OutputDatasetInterface] = (
+        pl_interfaces.OutputDatasetInterface.pyd_field(
+            alias="os",
+            is_required=False,
+            description=(
+                "Output dataset of sample selected by the query. "
+                "Leave to None to not save to disk."
+            ),
+            piper_port=PiperPortType.OUTPUT,
+        )
     )
 
-    output_discarded: t.Optional[
-        pl_interfaces.OutputDatasetInterface
-    ] = pl_interfaces.OutputDatasetInterface.pyd_field(
-        alias="od",
-        is_required=False,
-        description=(
-            "Output dataset of sample discarded by the query. "
-            "Leave to None to not save to disk."
-        ),
-        piper_port=PiperPortType.OUTPUT,
+    output_discarded: t.Optional[pl_interfaces.OutputDatasetInterface] = (
+        pl_interfaces.OutputDatasetInterface.pyd_field(
+            alias="od",
+            is_required=False,
+            description=(
+                "Output dataset of sample discarded by the query. "
+                "Leave to None to not save to disk."
+            ),
+            piper_port=PiperPortType.OUTPUT,
+        )
     )
 
     grabber: pl_interfaces.GrabberInterface = pl_interfaces.GrabberInterface.pyd_field(
@@ -353,9 +353,9 @@ class SplitByValueCommand(PipelimeCommand, title="split-value"):
                 if isinstance(value, np.ndarray):
                     if value.size == 1:
                         value = (
-                            int(value)
+                            int(value[0])
                             if np.issubdtype(value.dtype, np.integer)
-                            else float(value)
+                            else float(value[0])
                         )
                     else:
                         value = tuple(value)
@@ -379,7 +379,7 @@ class SplitByValueCommand(PipelimeCommand, title="split-value"):
                 if value is not None:  # pragma: no branch
                     value = self._value_to_str(value)
                     self._groups.setdefault(value, []).append(
-                        int(x[self._idx_key]())  # type: ignore
+                        int(x[self._idx_key]()[0])  # type: ignore
                     )
 
         reader = self.input.create_reader()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "dictquery",
     "minio",
     "requests",
-    "billiard",
     "textual>=0.26.0",
 ]
 dynamic = [ "version" ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 required_plugins = pytest-cov
 addopts = --cov=pipelime --cov-report html --cov-report term-missing
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/pipelime/cli/test_base.py
+++ b/tests/pipelime/cli/test_base.py
@@ -374,7 +374,9 @@ class TestCliBase:
         if not isinstance(with_default_ckpt, bool):
             # create fake command calls to fill the other default checkpoints
             for _ in range(with_default_ckpt - 1):
-                self._base_launch(["clone"], exit_code=1, exc=TypeError)
+                self._base_launch(
+                    ["clone", "--no-ui"], exit_code=1, exc=ValidationError
+                )
 
         # now resume from checkpoint and override the slice size (invalid value)
         self._base_launch(

--- a/tests/pipelime/cli/test_tui.py
+++ b/tests/pipelime/cli/test_tui.py
@@ -442,89 +442,98 @@ def test_create_title() -> None:
     assert len(labels) == 2
 
     title = FooCommand.command_title()
-    assert title in cast(str, labels[0].render())
+    assert title in str(labels[0].render())
 
     description = cast(str, FooCommand.__doc__)
     description = TuiApp.preprocess_string(description)
-    assert description in cast(str, labels[1].render())
+    assert description in str(labels[1].render())
 
 
 def test_create_simple_field() -> None:
-    app = TuiApp(FooCommand, {"i": "foo", "output_folder": "bar"})
+    async def task() -> None:
+        app = TuiApp(FooCommand, {"i": "foo", "output_folder": "bar"})
 
-    for f in ["input_folder", "output_folder", "debug", "grabber"]:
-        tui_field = app.fields[f]
+        async with app.run_test():
+            for f in ["input_folder", "output_folder", "debug", "grabber"]:
+                tui_field = app.fields[f]
 
-        widgets = app.create_simple_field(tui_field)
-        assert len(widgets) == 3
+                widgets = app.create_simple_field(tui_field)
+                assert len(widgets) == 3
 
-        title_label, description_label, input_ = widgets
-        title_label = cast(Label, title_label)
-        description_label = cast(Label, description_label)
-        input_ = cast(Input, input_)
+                title_label, description_label, input_ = widgets
+                title_label = cast(Label, title_label)
+                description_label = cast(Label, description_label)
+                input_ = cast(Input, input_)
 
-        assert tui_field.name in cast(str, title_label.render())
+                assert tui_field.name in str(title_label.render())
 
-        assert tui_field.type_ in cast(str, description_label.render())
-        assert tui_field.description in cast(str, description_label.render())
+                assert tui_field.type_ in str(description_label.render())
+                assert tui_field.description in str(description_label.render())
 
-        assert input_.value == tui_field.value
-        assert input_.placeholder == tui_field.hint
+                assert input_.value == tui_field.value
+                assert input_.placeholder == tui_field.hint
+
+    asyncio.run(task())
 
 
 def test_create_dict_field() -> None:
-    from pipelime.commands import MapCommand
+    async def task() -> None:
+        from pipelime.commands import MapCommand
 
-    PipelimeSymbolsHelper.set_extra_modules(["tests.pipelime.cli.test_tui"])
+        PipelimeSymbolsHelper.set_extra_modules(["tests.pipelime.cli.test_tui"])
 
-    app = TuiApp(MapCommand, {"stage": "foo-stage"})
-    stage_field = app.fields["stage"]
-    widgets = app.create_dict_field(stage_field)
+        app = TuiApp(MapCommand, {"stage": "foo-stage"})
 
-    assert len(widgets) == 8
+        async with app.run_test():
+            stage_field = app.fields["stage"]
+            widgets = app.create_dict_field(stage_field)
 
-    stage_title = cast(Label, widgets[0])
-    stage_description = cast(Label, widgets[1])
-    sub_field_0_title = cast(Label, widgets[2])
-    sub_field_0_description = cast(Label, widgets[3])
-    sub_field_0_input = cast(Input, widgets[4])
-    sub_field_1_title = cast(Label, widgets[5])
-    sub_field_1_description = cast(Label, widgets[6])
-    sub_field_1_input = cast(Input, widgets[7])
+            assert len(widgets) == 8
 
-    assert stage_field.name in cast(str, stage_title.render())
-    assert stage_field.description in cast(str, stage_description.render())
+            stage_title = cast(Label, widgets[0])
+            stage_description = cast(Label, widgets[1])
+            sub_field_0_title = cast(Label, widgets[2])
+            sub_field_0_description = cast(Label, widgets[3])
+            sub_field_0_input = cast(Input, widgets[4])
+            sub_field_1_title = cast(Label, widgets[5])
+            sub_field_1_description = cast(Label, widgets[6])
+            sub_field_1_input = cast(Input, widgets[7])
 
-    sub_field_0 = stage_field.values[0]
-    assert sub_field_0.name in cast(str, sub_field_0_title.render())
-    assert sub_field_0.type_ in cast(str, sub_field_0_description.render())
-    assert sub_field_0.description in cast(str, sub_field_0_description.render())
-    assert sub_field_0.value == sub_field_0_input.value
-    assert sub_field_0.hint == sub_field_0_input.placeholder
+            assert stage_field.name in str(stage_title.render())
+            assert stage_field.description in str(stage_description.render())
 
-    sub_field_1 = stage_field.values[1]
-    assert sub_field_1.name in cast(str, sub_field_1_title.render())
-    assert sub_field_1.type_ in cast(str, sub_field_1_description.render())
-    assert sub_field_1.description in cast(str, sub_field_1_description.render())
-    assert sub_field_1.value == sub_field_1_input.value
-    assert sub_field_1.hint == sub_field_1_input.placeholder
+            sub_field_0 = stage_field.values[0]
+            assert sub_field_0.name in str(sub_field_0_title.render())
+            assert sub_field_0.type_ in str(sub_field_0_description.render())
+            assert sub_field_0.description in str(sub_field_0_description.render())
+            assert sub_field_0.value == sub_field_0_input.value
+            assert sub_field_0.hint == sub_field_0_input.placeholder
 
-    for widget in [
-        sub_field_0_title,
-        sub_field_0_description,
-        sub_field_0_input,
-        sub_field_1_title,
-        sub_field_1_description,
-        sub_field_1_input,
-    ]:
-        assert widget.styles.margin == Constants.SUB_FIELD_MARGIN
+            sub_field_1 = stage_field.values[1]
+            assert sub_field_1.name in str(sub_field_1_title.render())
+            assert sub_field_1.type_ in str(sub_field_1_description.render())
+            assert sub_field_1.description in str(sub_field_1_description.render())
+            assert sub_field_1.value == sub_field_1_input.value
+            assert sub_field_1.hint == sub_field_1_input.placeholder
+
+            for widget in [
+                sub_field_0_title,
+                sub_field_0_description,
+                sub_field_0_input,
+                sub_field_1_title,
+                sub_field_1_description,
+                sub_field_1_input,
+            ]:
+                assert widget.styles.margin == Constants.SUB_FIELD_MARGIN
+
+    asyncio.run(task())
 
 
-def test_tui_ctrl_c() -> None:
+def test_tui_abort() -> None:
     async def task() -> None:
         app = TuiApp(FooCommand, {})
         async with app.run_test() as pilot:
-            # press "ctrl+c" to abort
+            # press the key combination to abort
             await pilot.press(Constants.TUI_KEY_ABORT)
 
     with pytest.raises(KeyboardInterrupt):
@@ -540,6 +549,8 @@ async def test_collect_cmd_args() -> None:
     app = TuiApp(FooCommand, {"i": "foo", "output_folder": "bar"})
 
     async with app.run_test() as pilot:
+        # move to the end of the input_folder input box
+        await pilot.press(Keys.End)
         # add "/path" after "foo" in input_folder input box
         await pilot.press("/", "p", "a", "t", "h")
 
@@ -606,7 +617,7 @@ async def test_toggle_descriptions() -> None:
 
     query = app.query(".description")
     for widget in query:
-        assert widget.styles.height.value == 0
+        assert widget.display is False
 
     async with app.run_test() as pilot:
         await pilot.press(Constants.TUI_KEY_TOGGLE_DESCRIPTIONS)
@@ -614,14 +625,14 @@ async def test_toggle_descriptions() -> None:
 
         query = app.query(".description")
         for widget in query:
-            assert widget.styles.height.value > 0
+            assert widget.display is True
 
         await pilot.press(Constants.TUI_KEY_TOGGLE_DESCRIPTIONS)
         assert app.show_descriptions is False
 
         query = app.query(".description")
         for widget in query:
-            assert widget.styles.height.value == 0
+            assert widget.display is False
 
 
 def test_preprocess_string() -> None:
@@ -645,22 +656,6 @@ def test_preprocess_string() -> None:
     assert splits[-1] == third_line.replace("[", r"\[")
 
 
-def test_save_screen_ctrl_c() -> None:
-    async def task() -> None:
-        app = TuiApp(FooCommand, {})
-        async with app.run_test() as pilot:
-            # launch the save screen
-            await pilot.press(Constants.TUI_KEY_SAVE)
-
-            assert len(app.screen_stack) == 2
-
-            # press "ctrl+c" to abort
-            await pilot.press(Constants.SAVE_KEY_ABORT)
-
-    with pytest.raises(KeyboardInterrupt):
-        asyncio.run(task())
-
-
 @pytest.mark.asyncio
 async def test_save_screen_cancel() -> None:
     app = TuiApp(FooCommand, {})
@@ -677,7 +672,7 @@ async def test_save_screen_cancel() -> None:
 
 
 @pytest.mark.asyncio
-async def test_save_screen_save() -> None:
+async def test_save_screen_save(tmp_path: Path) -> None:
     app = TuiApp(FooCommand, {"i": "foo"})
 
     async with app.run_test() as pilot:
@@ -692,9 +687,9 @@ async def test_save_screen_save() -> None:
         assert len(app.screen_stack) == 2
         # check that the error label is visible
         error_label = app.screen_stack[-1].query_one(".error-label")
-        assert error_label.styles.height.value > 0
+        assert error_label.display is True
         # check the error text
-        error_text = cast(str, error_label.render())
+        error_text = str(error_label.render())
         assert "Path cannot be empty." in error_text
 
         # enter a wrong save path
@@ -705,7 +700,7 @@ async def test_save_screen_save() -> None:
         # check that the save screen is still open
         assert len(app.screen_stack) == 2
         # check that the error text has changed
-        assert error_text != cast(str, error_label.render())
+        assert error_text != str(error_label.render())
 
         # enter a directory
         for c in "foo/bar":
@@ -717,7 +712,7 @@ async def test_save_screen_save() -> None:
         # check that the save screen is still open
         assert len(app.screen_stack) == 2
         # check the error text
-        assert "is a directory" in cast(str, error_label.render())
+        assert "is a directory" in str(error_label.render())
 
         # enter an existing file
         for c in "tests/":
@@ -729,19 +724,21 @@ async def test_save_screen_save() -> None:
         # check that the save screen is still open
         assert len(app.screen_stack) == 2
         # check the error text
-        assert "already exists" in cast(str, error_label.render())
+        assert "already exists" in str(error_label.render())
 
         # enter a correct save path
+        save_path = tmp_path / "temp_tui_cfg.yaml"
+
         for c in "pyproject.toml":
             await pilot.press(Keys.Backspace)
-        for c in "temp_tui_cfg.yaml":
+        for c in str(save_path):
             await pilot.press(c)
         # confirm
         await pilot.press(Constants.SAVE_KEY_CONFIRM)
         # check that the save screen is gone
         assert len(app.screen_stack) == 1
         # check the saved config
-        saved_cfg = yaml.safe_load(open("temp_tui_cfg.yaml", "r"))
+        saved_cfg = yaml.safe_load(open(save_path, "r"))
         assert saved_cfg == {
             "input_folder": "foo",
             "output_folder": "",
@@ -749,11 +746,9 @@ async def test_save_screen_save() -> None:
             "grabber": "",
         }
 
-        Path("temp_tui_cfg.yaml").unlink()
-
 
 @pytest.mark.asyncio
-async def test_tui_complete() -> None:
+async def test_tui_complete(tmp_path: Path) -> None:
     from pipelime.commands import MapCommand
 
     PipelimeSymbolsHelper.set_extra_modules(["tests.pipelime.cli.test_tui"])
@@ -786,6 +781,7 @@ async def test_tui_complete() -> None:
         await pilot.press(Keys.Tab)
 
         # add "/bar/path" to "foo"
+        await pilot.press(Keys.End)
         for c in "/bar/path":
             await pilot.press(c)
 
@@ -801,8 +797,9 @@ async def test_tui_complete() -> None:
 
         assert len(app.screen_stack) == 2
 
-        # enter a correct save path
-        for c in "temp_tui_cfg.yaml":
+        # enter a save path
+        cfg_save_path = tmp_path / "temp_tui_cfg.yaml"
+        for c in str(cfg_save_path):
             await pilot.press(c)
 
         # confirm
@@ -810,7 +807,7 @@ async def test_tui_complete() -> None:
 
         assert len(app.screen_stack) == 1
 
-        saved_cfg = yaml.safe_load(open("temp_tui_cfg.yaml", "r"))
+        saved_cfg = yaml.safe_load(open(cfg_save_path, "r"))
         assert saved_cfg == {
             "stage": {
                 "foo-stage": {
@@ -823,8 +820,6 @@ async def test_tui_complete() -> None:
             "output": {"name": "john", "surname": "doe", "age": 42},
             "grabber": "",
         }
-
-        Path("temp_tui_cfg.yaml").unlink()
 
         # confirm and exit the TUI
         await pilot.press(Constants.TUI_KEY_CONFIRM)

--- a/tests/pipelime/commands/test_split.py
+++ b/tests/pipelime/commands/test_split.py
@@ -1,9 +1,10 @@
-import pytest
-from .test_general_base import TestGeneralCommandsBase
 from pathlib import Path
-from pydantic import parse_obj_as, ValidationError
+
+import pytest
+from pydantic import ValidationError, parse_obj_as
 
 from ... import TestAssert
+from .test_general_base import TestGeneralCommandsBase
 
 
 class TestSplit(TestGeneralCommandsBase):

--- a/tests/pipelime/sequences/test_operations.py
+++ b/tests/pipelime/sequences/test_operations.py
@@ -210,7 +210,7 @@ class TestSamplesSequenceOperations:
         for (idx, s_sample), e_sample in zip(enumerate(source), enum_seq):
             assert "custom_id" in e_sample
             assert isinstance(e_sample["custom_id"], pli.TxtNumpyItem)
-            assert int(e_sample["custom_id"]()) == idx  # type: ignore
+            assert int(e_sample["custom_id"]()[0]) == idx  # type: ignore
             assert all(v == e_sample[k] for k, v in s_sample.items())
 
     @pytest.mark.parametrize("n", [1, 4, 10, 3.8, 4.2, 3.89])

--- a/tests/pipelime/stages/test_remotes.py
+++ b/tests/pipelime/stages/test_remotes.py
@@ -1,10 +1,11 @@
-import pytest
+import typing as t
 from pathlib import Path
 from urllib.parse import ParseResult
-import typing as t
 
-from pipelime.sequences import Sample, SamplesSequence
+import pytest
+
 from pipelime.remotes import make_remote_url
+from pipelime.sequences import Sample, SamplesSequence
 
 
 class TestRemotes:
@@ -30,9 +31,10 @@ class TestRemotes:
         keys_to_upload: t.Optional[t.Sequence[str]],
         check_data: bool,
     ):
-        from pipelime.stages import StageUploadToRemote
-        import pipelime.items as pli
         import numpy as np
+
+        import pipelime.items as pli
+        from pipelime.stages import StageUploadToRemote
 
         if isinstance(remote_urls, ParseResult):
             remote_urls = [remote_urls]
@@ -153,9 +155,11 @@ class TestRemotes:
     def test_incremental_file_upload(
         self, minimnist_private_dataset: dict, tmp_path: Path
     ):
-        import pipelime.items as pli
         from shutil import rmtree
+
         import numpy as np
+
+        import pipelime.items as pli
 
         # data lake
         remote_root = tmp_path / "file_remote"
@@ -170,7 +174,7 @@ class TestRemotes:
             minimnist_private_dataset["path"],
             even_output,
             remote_url,
-            lambda x: int(x["label"]()) % 2 == 0,  # type: ignore
+            lambda x: int(x["label"]()[0]) % 2 == 0,  # type: ignore
             minimnist_private_dataset["image_keys"],
             True,
         )
@@ -186,7 +190,7 @@ class TestRemotes:
             SamplesSequence.from_underfolder(
                 minimnist_private_dataset["path"], merge_root_items=False
             ).filter(
-                lambda x: int(x["label"]()) % 2 == 1  # type: ignore
+                lambda x: int(x["label"]()[0]) % 2 == 1  # type: ignore
             )  # type: ignore
         )
 
@@ -219,7 +223,7 @@ class TestRemotes:
         assert len(even_odd_reader) == minimnist_private_dataset["len"]
 
         for s1, s2 in zip(even_odd_reader, even_odd_partial_seq):
-            is_even = int(s1["label"]()) % 2 == 0  # type: ignore
+            is_even = int(s1["label"]()[0]) % 2 == 0  # type: ignore
             assert s1.keys() == s2.keys()
 
             for k, v1 in s1.items():
@@ -259,7 +263,9 @@ class TestRemotes:
         self, minimnist_private_dataset: dict, tmp_path: Path
     ):
         from shutil import rmtree
+
         import numpy as np
+
         import pipelime.items as pli
 
         # create two remotes
@@ -321,9 +327,10 @@ class TestRemotes:
         )
 
     def test_forget_source(self, minimnist_private_dataset: dict, tmp_path: Path):
-        from pipelime.stages import StageForgetSource
-        import pipelime.items as pli
         import numpy as np
+
+        import pipelime.items as pli
+        from pipelime.stages import StageForgetSource
 
         # create two remotes
         remote_a_root = tmp_path / "remote_a"

--- a/tests/pipelime/utils/test_context_managers.py
+++ b/tests/pipelime/utils/test_context_managers.py
@@ -36,12 +36,22 @@ def test_context_manager_list():
     ],
 )
 def test_catch_signals(to_catch, to_raise, should_interrupt):
-    from pipelime.utils.context_managers import CatchSignals
     import signal
+
+    from pipelime.utils.context_managers import CatchSignals
 
     if to_catch:
         to_catch = [getattr(signal, sig) for sig in to_catch]
     to_raise = getattr(signal, to_raise)
+
+    if to_raise not in [signal.SIGINT, signal.SIGTERM]:
+        if (to_catch is None) or (to_raise not in to_catch):
+            # catch the signal with standard library to avoid process termination
+
+            def handler(signum, frame):
+                pass
+
+            signal.signal(to_raise, handler)
 
     with CatchSignals(to_catch) as catcher:
         assert not catcher.interrupted


### PR DESCRIPTION
TUI fixes:
- The shortcut that we defined to kill the TUI is now used by `textual`, we replaced it with another one.
- `textual` does not allow any more to create text boxes with height=0, we changed the way that description boxes are shown/hidden.

Multiprocessing fixes:
- `billiard` caused random deadlocks, so it was replaced with `multiprocessing` from standard library.
- One of the advantages of `billiard` was the possibility of running nested processes, while `multiprocessing` doesn't allow it. We added an option in the `Grabber` to do that with some internal hack.