### PR TITLE
OutputValueInterface

### DIFF
--- a/pipelime/commands/interfaces.py
+++ b/pipelime/commands/interfaces.py
@@ -931,3 +931,9 @@ class OutputValueInterface(
         self._data = value
         with open(self.file, "w") as f:
             json.dump(self._data, f)
+
+    def __repr__(self) -> str:
+        return self.__piper_repr__()
+
+    def __piper_repr__(self) -> str:
+        return self.file.as_posix()

--- a/pipelime/commands/interfaces.py
+++ b/pipelime/commands/interfaces.py
@@ -881,6 +881,11 @@ class OutputValueInterface(
         ),
     )
 
+    @pyd.validator("file")
+    def resolve_file(cls, v: Path):
+        # see https://bugs.python.org/issue38671
+        return v.resolve().absolute()
+
     @classmethod
     def validate(cls, value):
         if isinstance(value, OutputValueInterface):

--- a/pipelime/commands/interfaces.py
+++ b/pipelime/commands/interfaces.py
@@ -911,11 +911,30 @@ class OutputValueInterface(
 
     @pyd.validator("exists_ok", always=True)
     def _check_file_exists(cls, v: bool, values: t.Mapping[str, t.Any]) -> bool:
-        if (v is False) and (values["file"].exists()):
-            raise ValueError(
-                f"Trying to overwrite an existing file: `{values['file']}`. "
-                "Please use `exists_ok=True` to overwrite."
-            )
+        if "file" not in values:
+            # the "file" validator already failed
+            return v
+
+        if v is True:
+            if values["file"].is_dir():
+                raise ValueError(
+                    f"Cannot overwrite the directory: `{values['file']}`. "
+                    "Please provide a file path."
+                )
+
+        if v is False:
+            if values["file"].is_dir():
+                raise ValueError(
+                    f"Trying to overwrite the directory: `{values['file']}`. "
+                    "Please provide a file path and use `exists_ok=True` to overwrite."
+                )
+
+            if values["file"].exists():
+                raise ValueError(
+                    f"Trying to overwrite an existing file: `{values['file']}`. "
+                    "Please use `exists_ok=True` to overwrite."
+                )
+
         return v
 
     def get(self) -> ValueType:

--- a/tests/pipelime/cli/test_tui.py
+++ b/tests/pipelime/cli/test_tui.py
@@ -615,21 +615,26 @@ async def test_collect_cmd_args() -> None:
 async def test_toggle_descriptions() -> None:
     app = TuiApp(FooCommand, {})
 
-    query = app.query(".description")
-    for widget in query:
-        assert widget.display is False
-
     async with app.run_test() as pilot:
+        # check that descriptions are not shown by default
+        query = app.query(".description")
+        for widget in query:
+            assert widget.display is False
+
+        # toggle descriptions on
         await pilot.press(Constants.TUI_KEY_TOGGLE_DESCRIPTIONS)
         assert app.show_descriptions is True
 
+        # check that descriptions are shown
         query = app.query(".description")
         for widget in query:
             assert widget.display is True
 
+        # toggle descriptions off
         await pilot.press(Constants.TUI_KEY_TOGGLE_DESCRIPTIONS)
         assert app.show_descriptions is False
 
+        # check that descriptions are not shown
         query = app.query(".description")
         for widget in query:
             assert widget.display is False


### PR DESCRIPTION
This PR adds a new interface for pipelime commands, the `OutputValueInterface`. This interface allows commands to have outputs with primitive types (e.g. `int`, `float`, `str`, `bool`) that are automatically saved on files when a new value is set.